### PR TITLE
Remove AMC

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,8 @@
 source 'https://rubygems.org'
 
 gemspec
+
+group :test do
+  gem 'rspec', '~> 3.6.0'
+  gem 'byebug'
+end

--- a/activerecord-create_decorator.gemspec
+++ b/activerecord-create_decorator.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'activerecord-create_decorator'
-  s.version = '0.1.0.1'
+  s.version = '0.1.1'
   s.author = 'GoDaddy'
   s.email = 'nemo-engg@godaddy.com'
   s.licenses = ['MIT']

--- a/activerecord-create_decorator.gemspec
+++ b/activerecord-create_decorator.gemspec
@@ -1,10 +1,11 @@
 Gem::Specification.new do |s|
   s.name = 'activerecord-create_decorator'
-  s.version = '0.1.0.0'
-  s.author = 'Team Nemo'
+  s.version = '0.1.0.1'
+  s.author = 'GoDaddy'
   s.email = 'nemo-engg@godaddy.com'
+  s.licenses = ['MIT']
   s.summary = 'Applies connection-specific options when creating tables through ActiveRecord'
-  s.description = 'See summary'
+  s.description = ''
   s.homepage = 'https://github.secureserver.net/PC/activerecord-create_decorator'
   s.files = Dir['lib/**'] + ['README.md']
 

--- a/lib/activerecord-create_decorator.rb
+++ b/lib/activerecord-create_decorator.rb
@@ -1,1 +1,1 @@
-require 'activerecord/schema_statements_ext'
+require 'activerecord/abstract_adapter_ext'

--- a/lib/activerecord/abstract_adapter_ext.rb
+++ b/lib/activerecord/abstract_adapter_ext.rb
@@ -1,4 +1,4 @@
-module ActiveRecord::ConnectionAdapters::SchemaStatementsExt
+module ActiveRecord::ConnectionAdapters::AbstractAdapterExt
   def create_table(table_name, options={}, &block)
     create_options = ActiveRecord::Base.connection_config[:create_options]
     if create_options
@@ -15,4 +15,4 @@ module ActiveRecord::ConnectionAdapters::SchemaStatementsExt
 end
 
 # bundle modified behavior with the AbstractAdapter class
-ActiveRecord::ConnectionAdapters::AbstractAdapter.include ActiveRecord::ConnectionAdapters::SchemaStatementsExt
+ActiveRecord::ConnectionAdapters::AbstractAdapter.include ActiveRecord::ConnectionAdapters::AbstractAdapterExt

--- a/lib/activerecord/schema_statements_ext.rb
+++ b/lib/activerecord/schema_statements_ext.rb
@@ -14,13 +14,8 @@ module ActiveRecord::ConnectionAdapters::SchemaStatementsExt
   end
 end
 
-# bundle modified behavior with the SchemaStatements module
-ActiveRecord::ConnectionAdapters::SchemaStatements.module_eval do
-
-  # when SchemaStatements is included, add SchemaStatementsExt overrides
-  def self.included(mod)
-    mod.include ActiveRecord::ConnectionAdapters::SchemaStatementsExt 
-  end
-
+# bundle modified behavior with the AbstractAdapter class
+ActiveRecord::ConnectionAdapters::AbstractAdapter.class_eval do
+  include ActiveRecord::ConnectionAdapters::SchemaStatementsExt
 end
 

--- a/lib/activerecord/schema_statements_ext.rb
+++ b/lib/activerecord/schema_statements_ext.rb
@@ -1,25 +1,26 @@
-ActiveRecord.module_eval do
-  ActiveRecord::ConnectionAdapters.module_eval do
-    ActiveRecord::ConnectionAdapters::SchemaStatements.module_eval do
-      def create_table_with_options_decoration(table_name, options={}, &block)
-        create_options = ActiveRecord::Base.connection_config[:create_options]
-        if create_options
-          current_options = options[:options]
-          if current_options
-            options[:options] = "#{current_options} #{create_options}"
-          else
-            options[:options] = create_options
-          end
-        end
-
-        if block_given?
-          create_table_without_options_decoration(table_name, options, &block)
-        else
-          create_table_without_options_decoration(table_name, options)
-        end
+module ActiveRecord::ConnectionAdapters::SchemaStatementsExt
+  def create_table(table_name, options={}, &block)
+    create_options = ActiveRecord::Base.connection_config[:create_options]
+    if create_options
+      current_options = options[:options]
+      if current_options
+        options[:options] = "#{current_options} #{create_options}"
+      else
+        options[:options] = create_options
       end
-
-      alias_method_chain :create_table, :options_decoration
     end
+
+    super
   end
 end
+
+# bundle modified behavior with the SchemaStatements module
+ActiveRecord::ConnectionAdapters::SchemaStatements.module_eval do
+
+  # when SchemaStatements is included, add SchemaStatementsExt overrides
+  def self.included(mod)
+    mod.include ActiveRecord::ConnectionAdapters::SchemaStatementsExt 
+  end
+
+end
+

--- a/lib/activerecord/schema_statements_ext.rb
+++ b/lib/activerecord/schema_statements_ext.rb
@@ -15,7 +15,4 @@ module ActiveRecord::ConnectionAdapters::SchemaStatementsExt
 end
 
 # bundle modified behavior with the AbstractAdapter class
-ActiveRecord::ConnectionAdapters::AbstractAdapter.class_eval do
-  include ActiveRecord::ConnectionAdapters::SchemaStatementsExt
-end
-
+ActiveRecord::ConnectionAdapters::AbstractAdapter.include ActiveRecord::ConnectionAdapters::SchemaStatementsExt

--- a/spec/lib/activerecord/schema_statements_ext_spec.rb
+++ b/spec/lib/activerecord/schema_statements_ext_spec.rb
@@ -8,8 +8,9 @@ RSpec.describe ActiveRecord::ConnectionAdapters::SchemaStatementsExt do
   let(:both_options) { 'current_options base_options' }
   let(:block) { TestClass.block_was_called }
 
-  class TestClass
+  class TestClass # mimics AbstractAdapter
     include ActiveRecord::ConnectionAdapters::SchemaStatements
+    include ActiveRecord::ConnectionAdapters::SchemaStatementsExt
 
     def self.block_was_called
     end

--- a/spec/lib/activerecord/schema_statements_ext_spec.rb
+++ b/spec/lib/activerecord/schema_statements_ext_spec.rb
@@ -16,14 +16,16 @@ RSpec.describe ActiveRecord::ConnectionAdapters::SchemaStatementsExt do
   end
 
   before(:each) do
-    expect_any_instance_of(TestClass).to receive_message_chain(:schema_creation, :accept)
-    expect_any_instance_of(TestClass).to receive(:execute)
-    expect_any_instance_of(TestClass).to receive(:supports_indexes_in_create?)
-    expect_any_instance_of(TestClass).to receive(:supports_comments?)
     expect(TestClass).to receive(:block_was_called)
+    expect_any_instance_of(TestClass).to receive(:execute)
+    allow_any_instance_of(TestClass).to receive_message_chain(:schema_creation, :accept)
+    allow_any_instance_of(TestClass).to receive(:supports_indexes_in_create?)
+    allow_any_instance_of(TestClass).to receive(:supports_comments?)
   end
 
   describe '#create_table' do
+    # any_args is used to bridge differences between ActiveRecord versions
+
     context 'with create_options' do
       before(:each) do
         allow(ActiveRecord::Base).to receive(:connection_config).and_return({ create_options: create_options })
@@ -32,7 +34,7 @@ RSpec.describe ActiveRecord::ConnectionAdapters::SchemaStatementsExt do
       context 'with current_options' do
         it 'adds connection config to options arg and forwards to parent' do
           expect_any_instance_of(TestClass).to receive(:create_table_definition).with(
-            table, nil, both_options, nil, { comment: nil }).and_call_original
+            table, nil, both_options, any_args).and_call_original
 
           TestClass.new.create_table(table, { options: current_options }) { block }
         end
@@ -41,7 +43,7 @@ RSpec.describe ActiveRecord::ConnectionAdapters::SchemaStatementsExt do
       context 'without current_options' do
         it 'sends connection config as option' do
           expect_any_instance_of(TestClass).to receive(:create_table_definition).with(
-            table, nil, create_options, nil, { comment: nil }).and_call_original
+            table, nil, create_options, any_args).and_call_original
 
           TestClass.new.create_table(table) { block }
         end
@@ -56,7 +58,7 @@ RSpec.describe ActiveRecord::ConnectionAdapters::SchemaStatementsExt do
       context 'with current_options' do
         it 'sends just current_options' do
           expect_any_instance_of(TestClass).to receive(:create_table_definition).with(
-            table, nil, current_options, nil, { comment: nil }).and_call_original
+            table, nil, current_options, any_args).and_call_original
 
           TestClass.new.create_table(table, { options: current_options }) { block }
         end
@@ -65,7 +67,7 @@ RSpec.describe ActiveRecord::ConnectionAdapters::SchemaStatementsExt do
       context 'without current_options' do
         it 'sends no options' do
           expect_any_instance_of(TestClass).to receive(:create_table_definition).with(
-            table, nil, nil, nil, { comment: nil }).and_call_original
+            table, nil, nil, any_args).and_call_original
 
           TestClass.new.create_table(table) { block }
         end

--- a/spec/lib/activerecord/schema_statements_ext_spec.rb
+++ b/spec/lib/activerecord/schema_statements_ext_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+
+RSpec.describe ActiveRecord::ConnectionAdapters::SchemaStatementsExt do
+
+  let(:table) { 'table_name' }
+  let(:create_options) { 'base_options' }
+  let(:current_options) { 'current_options' }
+  let(:both_options) { 'current_options base_options' }
+  let(:block) { TestClass.block_was_called }
+
+  class TestClass
+    include ActiveRecord::ConnectionAdapters::SchemaStatements
+
+    def self.block_was_called
+    end
+  end
+
+  before(:each) do
+    expect_any_instance_of(TestClass).to receive_message_chain(:schema_creation, :accept)
+    expect_any_instance_of(TestClass).to receive(:execute)
+    expect_any_instance_of(TestClass).to receive(:supports_indexes_in_create?)
+    expect_any_instance_of(TestClass).to receive(:supports_comments?)
+    expect(TestClass).to receive(:block_was_called)
+  end
+
+  describe '#create_table' do
+    context 'with create_options' do
+      before(:each) do
+        allow(ActiveRecord::Base).to receive(:connection_config).and_return({ create_options: create_options })
+      end
+
+      context 'with current_options' do
+        it 'adds connection config to options arg and forwards to parent' do
+          expect_any_instance_of(TestClass).to receive(:create_table_definition).with(
+            table, nil, both_options, nil, { comment: nil }).and_call_original
+
+          TestClass.new.create_table(table, { options: current_options }) { block }
+        end
+      end
+
+      context 'without current_options' do
+        it 'sends connection config as option' do
+          expect_any_instance_of(TestClass).to receive(:create_table_definition).with(
+            table, nil, create_options, nil, { comment: nil }).and_call_original
+
+          TestClass.new.create_table(table) { block }
+        end
+      end
+    end
+
+    context 'without create_options' do
+      before(:each) do
+        allow(ActiveRecord::Base).to receive(:connection_config).and_return({})
+      end
+
+      context 'with current_options' do
+        it 'sends just current_options' do
+          expect_any_instance_of(TestClass).to receive(:create_table_definition).with(
+            table, nil, current_options, nil, { comment: nil }).and_call_original
+
+          TestClass.new.create_table(table, { options: current_options }) { block }
+        end
+      end
+
+      context 'without current_options' do
+        it 'sends no options' do
+          expect_any_instance_of(TestClass).to receive(:create_table_definition).with(
+            table, nil, nil, nil, { comment: nil }).and_call_original
+
+          TestClass.new.create_table(table) { block }
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/activerecord/schema_statements_ext_spec.rb
+++ b/spec/lib/activerecord/schema_statements_ext_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe ActiveRecord::ConnectionAdapters::SchemaStatementsExt do
+RSpec.describe ActiveRecord::ConnectionAdapters::AbstractAdapterExt do
 
   let(:table) { 'table_name' }
   let(:create_options) { 'base_options' }
@@ -10,7 +10,7 @@ RSpec.describe ActiveRecord::ConnectionAdapters::SchemaStatementsExt do
 
   class TestClass # mimics AbstractAdapter
     include ActiveRecord::ConnectionAdapters::SchemaStatements
-    include ActiveRecord::ConnectionAdapters::SchemaStatementsExt
+    include ActiveRecord::ConnectionAdapters::AbstractAdapterExt
 
     def self.block_was_called
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'active_record'
-require_relative '../lib/activerecord/schema_statements_ext.rb'
+require_relative '../lib/activerecord/abstract_adapter_ext.rb'
 
 RSpec.configure do |config|
   config.order = "random"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,6 @@
+require 'active_record'
+require_relative '../lib/activerecord/schema_statements_ext.rb'
+
+RSpec.configure do |config|
+  config.order = "random"
+end


### PR DESCRIPTION
Removing deprecated `alias_method_chain` approach (which currently throws warnings from Rails) in favor of a more standard module override approach. 
Since SchemaStatements is, itself, a module, I took the approach of injecting an `included` method into it and have that method also include the override module. An simplified proof of concept of this approach looks like this:
```
[1] pry(main)> module Test
[1] pry(main)*   def run
[1] pry(main)*     puts "test"
[1] pry(main)*   end
[1] pry(main)* end
=> :run
[2] pry(main)> module TestModifier
[2] pry(main)*   def run
[2] pry(main)*     puts "test modified"
[2] pry(main)*     super
[2] pry(main)*   end
[2] pry(main)* end
=> :run
[3] pry(main)> Test.module_eval do
[3] pry(main)*   def self.included(mod)
[3] pry(main)*     mod.include TestModifier
[3] pry(main)*   end
[3] pry(main)* end
=> :included
[4] pry(main)> class X
[4] pry(main)*   include Test
[4] pry(main)* end
=> X
[5] pry(main)> X.new.run
test modified
test
```

I unfortunately didn't find time to add rspec and corresponding tests to this (there've apparently never been any), but thought it worth getting this up for review/conversation, at least.