### PR TITLE
include necessary files in build

### DIFF
--- a/activerecord-create_decorator.gemspec
+++ b/activerecord-create_decorator.gemspec
@@ -1,13 +1,13 @@
 Gem::Specification.new do |s|
   s.name = 'activerecord-create_decorator'
-  s.version = '0.1.1'
+  s.version = '0.1.2'
   s.author = 'GoDaddy'
   s.email = 'nemo-engg@godaddy.com'
   s.licenses = ['MIT']
   s.summary = 'Applies connection-specific options when creating tables through ActiveRecord'
   s.description = ''
   s.homepage = 'https://github.secureserver.net/PC/activerecord-create_decorator'
-  s.files = Dir['lib/**'] + ['README.md']
+  s.files = Dir['lib/**/*'] + ['README.md']
 
   s.add_dependency             "activerecord", ">= 3.2"
 end


### PR DESCRIPTION
From rubygems [docs](https://guides.rubygems.org/specification-reference/#files) directories are filtered out of gem builds.

This change should allow `lib/activerecord/abstract_adapter_ext.rb` to be successfully required.